### PR TITLE
fix menu scroll bug

### DIFF
--- a/src/templates/post/index.js
+++ b/src/templates/post/index.js
@@ -34,6 +34,16 @@ class PostTemplate extends Component {
   }
 
   onChange = isVisible => {
+    let scrollTop = window.pageYOffset
+                || document.documentElement.scrollTop
+                || document.body.scrollTop
+                || 0
+    if(scrollTop > -480  && scrollTop < 480){
+      this.setState({
+        fix: false,
+      })
+      return 
+    }
     this.setState({
       fix: !isVisible,
     });


### PR DESCRIPTION
因为没有判定滚动高度，当浏览器高度低于480，滚动高度较小，此时markdown目录仍然会fixed显示，导致悬浮在header上